### PR TITLE
strict mode fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configcat-react",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-react",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "configcat-common": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-react",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc -p tsconfig.build.esm.json && gulp esm",

--- a/samples/react-sdk-sample/src/ConfigCatHOC.tsx
+++ b/samples/react-sdk-sample/src/ConfigCatHOC.tsx
@@ -11,7 +11,18 @@ class ButtonClassComponent extends React.Component<
     this.state = { isEnabled: false, loading: true };
   }
 
+  componentDidUpdate(prevProps: any) {
+    // To achieve hot reload on config.json updates.
+    if (prevProps?.lastUpdated !== this.props.lastUpdated) {
+      this.evaluateFeatureFlag();
+    }
+  }
+
   componentDidMount() {
+    this.evaluateFeatureFlag();
+  }
+
+  evaluateFeatureFlag() {
     this.props
       .getValue("isAwesomeFeatureEnabled", false)
       .then((v: boolean) => this.setState({ isEnabled: v, loading: false }));

--- a/src/ConfigCatProvider.tsx
+++ b/src/ConfigCatProvider.tsx
@@ -45,11 +45,9 @@ class ConfigCatProvider extends Component<
     this.state?.client?.removeListener("clientReady", () => this.clientReady);
     this.state?.client?.removeListener("configChanged", newConfig => this.reactConfigChanged(newConfig));
 
-    if (initializedClients.has(this.props.sdkKey)) {
-      initializedClients.set(this.props.sdkKey, initializedClients[this.props.sdkKey]--);
-    }
+    initializedClients.set(this.props.sdkKey, (initializedClients.get(this.props.sdkKey) ?? 1) - 1);
 
-    if (initializedClients[this.props.sdkKey] === 0) {
+    if (initializedClients.get(this.props.sdkKey) === 0) {
       this.state?.client?.dispose();
       initializedClients.delete(this.props.sdkKey);
     }
@@ -65,7 +63,7 @@ class ConfigCatProvider extends Component<
       sdkVersion: CONFIGCAT_SDK_VERSION
     };
 
-    initializedClients.set(sdkKey, initializedClients[sdkKey]++);
+    initializedClients.set(sdkKey, (initializedClients.get(sdkKey) ?? 0) + 1);
     return configcatcommon.getClient(sdkKey, pollingMode ?? PollingMode.AutoPoll, options, configCatKernel);
   }
 

--- a/src/ConfigCatProvider.tsx
+++ b/src/ConfigCatProvider.tsx
@@ -20,6 +20,8 @@ type ConfigCatProviderState = {
   lastUpdated?: Date;
 };
 
+const initializedClients = new Map<string, number>();
+
 class ConfigCatProvider extends Component<
   /* eslint-disable @typescript-eslint/indent */
   PropsWithChildren<ConfigCatProviderProps>,
@@ -34,12 +36,27 @@ class ConfigCatProvider extends Component<
     this.state = { client };
   }
 
+  componentDidMount(): void {
+    this.state?.client?.on("clientReady", () => this.clientReady);
+    this.state?.client?.on("configChanged", newConfig => this.reactConfigChanged(newConfig));
+  }
+
   componentWillUnmount(): void {
-    this.state?.client?.dispose();
+    this.state?.client?.removeListener("clientReady", () => this.clientReady);
+    this.state?.client?.removeListener("configChanged", newConfig => this.reactConfigChanged(newConfig));
+
+    if (initializedClients.has(this.props.sdkKey)) {
+      initializedClients.set(this.props.sdkKey, initializedClients[this.props.sdkKey]--);
+    }
+
+    if (initializedClients[this.props.sdkKey] === 0) {
+      this.state?.client?.dispose();
+      initializedClients.delete(this.props.sdkKey);
+    }
   }
 
   private initializeConfigCatClient() {
-    let { pollingMode, options } = this.props;
+    const { pollingMode, options } = this.props;
     const { sdkKey } = this.props;
     const configCatKernel = {
       configFetcher: new HttpConfigFetcher(),
@@ -48,32 +65,15 @@ class ConfigCatProvider extends Component<
       sdkVersion: CONFIGCAT_SDK_VERSION
     };
 
-    pollingMode ??= PollingMode.AutoPoll;
-
-    options ??= {};
-    const userSetupHooks = options.setupHooks;
-    options.setupHooks = hooks => {
-      hooks.on("clientReady", () => this.clientReady());
-      hooks.on("configChanged", newConfig => this.reactConfigChanged(newConfig));
-      userSetupHooks?.(hooks);
-    };
-
-    return configcatcommon.getClient(sdkKey, pollingMode, options, configCatKernel);
+    initializedClients.set(sdkKey, initializedClients[sdkKey]++);
+    return configcatcommon.getClient(sdkKey, pollingMode ?? PollingMode.AutoPoll, options, configCatKernel);
   }
 
   reactConfigChanged(newConfig: ProjectConfig): void {
-    if (!this.state) {
-      // Initialization phase will set state anyway.
-      return;
-    }
     this.setState({ lastUpdated: new Date(newConfig.Timestamp) });
   }
 
   clientReady(): void {
-    if (!this.state) {
-      // Initialization phase will set state anyway.
-      return;
-    }
     this.setState({ lastUpdated: new Date() });
   }
 

--- a/src/ConfigCatProvider.tsx
+++ b/src/ConfigCatProvider.tsx
@@ -37,12 +37,12 @@ class ConfigCatProvider extends Component<
   }
 
   componentDidMount(): void {
-    this.state?.client?.on("clientReady", () => this.clientReady);
+    this.state?.client?.on("clientReady", () => this.clientReady());
     this.state?.client?.on("configChanged", newConfig => this.reactConfigChanged(newConfig));
   }
 
   componentWillUnmount(): void {
-    this.state?.client?.removeListener("clientReady", () => this.clientReady);
+    this.state?.client?.removeListener("clientReady", () => this.clientReady());
     this.state?.client?.removeListener("configChanged", newConfig => this.reactConfigChanged(newConfig));
 
     initializedClients.set(this.props.sdkKey, (initializedClients.get(this.props.sdkKey) ?? 1) - 1);


### PR DESCRIPTION
### Describe the purpose of your pull request

In React 18, when you are in strict mode (this happens only in development), the component is mounted twice.
mounted -> instantly unmounted -> instantly remounted

This was not compatible with the new singleton approach of the configcat-common lib.

I added a counter to the sdk initialization so we only dispose the client if necessary. 
I also updated the sample app a bit (hoc case).

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
