### PR TITLE
fix(Hook): Support re-evaluation on user change

### DIFF
--- a/src/ConfigCatHooks.tsx
+++ b/src/ConfigCatHooks.tsx
@@ -2,22 +2,30 @@ import type { IConfigCatClient, User } from "configcat-common";
 import { useContext, useEffect, useState } from "react";
 import ConfigCatContext from "./ConfigCatContext";
 
-function useFeatureFlag(key: string, defaultValue: any, user?: User | undefined): {
-  value: any;
-  loading: boolean;
-} {
+function useFeatureFlag(
+  key: string,
+  defaultValue: any,
+  user?: User | undefined,
+  reevaluateOnUserChange?: boolean | undefined,
+): { value: any; loading: boolean } {
   const configCatContext = useContext(ConfigCatContext);
 
   if (configCatContext === void 0) throw Error("useFeatureFlag hook must be used in ConfigCatProvider!");
 
   const [featureFlagValue, setFeatureFlag] = useState(defaultValue);
   const [loading, setLoading] = useState(true);
-  const [userState] = useState(user);
+  const [userState, setUserState] = useState(user);
+
+  useEffect(() => {
+    if (reevaluateOnUserChange) {
+      setUserState(user);
+    }
+  }, [user]);
 
   useEffect(() => {
     configCatContext.client.getValueAsync(key, defaultValue, userState)
       .then(v => { setFeatureFlag(v); setLoading(false); });
-  }, [configCatContext, key, defaultValue]);
+  }, [configCatContext, key, defaultValue, userState]);
 
   return { value: featureFlagValue, loading };
 }


### PR DESCRIPTION
Introduce a new property to the useFeatureFlag hook to enable the re-evaluation of feature flags whenever the user changes.

Currently, the useFeatureFlag uses the user within a useEffect hook without specifying it as a dependency. This causes the useEffect hook to not re-trigger when the user changes.
Because of this, the feature flag will still have the state based on the old user.

To fix this, the user could simply be added to the dependencies of the useEffect. But this could mean a breaking change:
Callers may create a new user object on every re-render. Because the user is an object and not a simple string or the like, useEffect would re-render even if the contents of the user didn't change but only the instance. This will result in an infinite loop.
Additionally, users may not expect this re-evaluation logic.

To not introduce this breaking change, don't make the re-evaluation the default. Instead, use a new optional property to enable this new logic.
If wanted, this logic may be made the default in the future.

Fixes: #27 