### PR TITLE
replaced XMLHttpRequest with fetch

### DIFF
--- a/src/ConfigFetcher.ts
+++ b/src/ConfigFetcher.ts
@@ -1,49 +1,30 @@
 import type { IConfigFetcher, IFetchResponse, OptionsBase } from "configcat-common";
-import { FetchError } from "configcat-common";
 
 export class HttpConfigFetcher implements IConfigFetcher {
-  private handleStateChange(httpRequest: XMLHttpRequest, resolve: (value: IFetchResponse) => void, reject: (reason?: any) => void) {
-    try {
-      if (httpRequest.readyState === 4) {
-        const { status: statusCode, statusText: reasonPhrase } = httpRequest;
+  fetchLogic(options: OptionsBase, _: string | null): Promise<IFetchResponse> {
+    return new Promise<IFetchResponse>((resolve, reject) => {
+      options.logger.debug("HttpConfigFetcher.fetchLogic() called.");
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), options.requestTimeoutMs);
 
+      fetch(options.getUrl(), {
+        method: "GET",
+        signal: controller.signal
+      }).then(response => {
+        const statusCode = response.status;
+        const reasonPhrase = response.statusText;
         if (statusCode === 200) {
-          const eTag: string | undefined = httpRequest.getResponseHeader("ETag") ?? void 0;
-          resolve({ statusCode, reasonPhrase, eTag, body: httpRequest.responseText });
+          const eTag: string | undefined = response.headers.get("ETag") ?? void 0;
+          response.text().then(body => {
+            resolve({ statusCode, eTag, body, reasonPhrase });
+          });
         }
-        // The readystatechange event is emitted even in the case of abort or error.
-        // We can detect this by checking for zero status code (see https://stackoverflow.com/a/19247992/8656352).
         else if (statusCode) {
           resolve({ statusCode, reasonPhrase });
         }
-      }
-    }
-    catch (err) {
-      reject(err);
-    }
-  }
-
-  fetchLogic(options: OptionsBase, _: string | null): Promise<IFetchResponse> {
-    return new Promise<IFetchResponse>((resolve, reject) => {
-      try {
-        options.logger.debug("HttpConfigFetcher.fetchLogic() called.");
-
-        const httpRequest: XMLHttpRequest = new XMLHttpRequest();
-
-        httpRequest.onreadystatechange = () => this.handleStateChange(httpRequest, resolve, reject);
-        httpRequest.ontimeout = () => reject(new FetchError("timeout", options.requestTimeoutMs));
-        httpRequest.onabort = () => reject(new FetchError("abort"));
-        httpRequest.onerror = () => reject(new FetchError("failure"));
-
-        httpRequest.open("GET", options.getUrl(), true);
-        httpRequest.timeout = options.requestTimeoutMs;
-        // NOTE: It's intentional that we don't specify the If-None-Match header.
-        // The browser automatically handles it, adding it manually would cause an unnecessary CORS OPTIONS request.
-        httpRequest.send(null);
-      }
-      catch (err) {
-        reject(err);
-      }
+      })
+      .catch(reject)
+      .finally(() => clearTimeout(timeoutId));
     });
   }
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

Removed the annoying `error - unhandledRejection: ReferenceError: XMLHttpRequest is not defined` logs by using `fetch` instead of `XMLHttpRequest`

### Related issues (only if applicable)

- https://github.com/configcat/react-sdk/issues/7

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
