### PR TITLE
Update ConfigCatHooks.tsx

### DIFF
--- a/src/ConfigCatHooks.tsx
+++ b/src/ConfigCatHooks.tsx
@@ -14,6 +14,7 @@ function useFeatureFlag<T extends SettingValue>(key: string, defaultValue: T, us
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    setLoading(true);
     configCatContext.client.getValueAsync(key, defaultValue, user)
       .then(v => { setFeatureFlag(v); setLoading(false); });
   }, [configCatContext, key, defaultValue, JSON.stringify(user)]);


### PR DESCRIPTION
set loading to true when we are about to call getValueAsync

### Describe the purpose of your pull request


Maybe there is a better way to do this.

Ideally we would get value immediately after user change, but since we are using useEffect here - it usually takes 2 re-renders to get updated value. Meaning there is no way from app perspective to know if we're getting stale value or not.

With setting loading to true - at least app can see that there is loading happening, but that probably introduces a 3 re-render...

in react-query - there are 2 flags for example isLoading when we have no data and have to load it and isFetching when we have data but we're loading new data - so user can decide if they want to use stale data or not. 

Ideally though we should decrease number of re-renders IMO.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
