### PR TITLE
Cache latin1 fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configcat-react",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-react",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "configcat-common": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-react",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc -p tsconfig.build.esm.json && gulp esm",

--- a/src/Cache.test.ts
+++ b/src/Cache.test.ts
@@ -1,0 +1,10 @@
+import { LocalStorageCache } from "./Cache";
+
+it("LocalStorageCache works with non latin 1 characters", () => {
+    const cache = new LocalStorageCache();
+    const key = "testkey";
+    const text = "äöüÄÖÜçéèñışğâ¢™✓😀";
+    cache.set(key, text);
+    const retrievedValue = cache.get(key);
+    expect(retrievedValue).toStrictEqual(text);
+});

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -3,7 +3,7 @@ import type { IConfigCatCache } from "configcat-common";
 export class LocalStorageCache implements IConfigCatCache {
   set(key: string, value: string): void {
     try {
-      localStorage.setItem(key, btoa(value));
+      localStorage.setItem(key, this.b64EncodeUnicode(value));
     }
     catch (ex) {
       // local storage is unavailable
@@ -14,12 +14,24 @@ export class LocalStorageCache implements IConfigCatCache {
     try {
       const configString = localStorage.getItem(key);
       if (configString) {
-        return atob(configString);
+        return this.b64DecodeUnicode(configString);
       }
     }
     catch (ex) {
       // local storage is unavailable or invalid cache value in localstorage
     }
     return void 0;
+  }
+
+  private b64EncodeUnicode(str: string): string {
+    return btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function (_, p1) {
+      return String.fromCharCode(parseInt(p1, 16))
+    }));
+  }
+
+  private b64DecodeUnicode(str: string): string {
+    return decodeURIComponent(Array.prototype.map.call(atob(str), function (c: string) {
+      return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+    }).join(''));
   }
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

The localstorage cache is not working with non Latin 1 characters.
Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
