### PR TITLE
Multiple providers support improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build:esm": "tsc -p tsconfig.build.esm.json && gulp esm",
     "build:cjs": "tsc -p tsconfig.build.cjs.json && gulp cjs",
     "prepare": "npm run build",
-    "test": "react-scripts test --detectOpenHandles",
+    "test": "react-scripts test --detectOpenHandles --runInBand --no-cache",
     "lint": "eslint . --ext .ts --ext .tsx",
     "lint:fix": "eslint . --ext .ts --ext .tsx --fix"
   },

--- a/src/ConfigCatContext.tsx
+++ b/src/ConfigCatContext.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { IConfigCatClient } from "configcat-common";
 import React from "react";
 
@@ -9,33 +7,47 @@ export interface ConfigCatContextData {
 }
 
 /** @remarks Map key: provider id normalized to lower case. */
-const ConfigCatContextRegistry = new Map<string, { context: React.Context<ConfigCatContextData | undefined>; isReserved?: boolean }>();
+const ConfigCatContextRegistry = new Map<string, {
+  context: React.Context<ConfigCatContextData | undefined>;
+  refCount: number;
+}>();
 
 function registryKeyFor(providerId: string | undefined) {
   return providerId ? providerId.toLowerCase() : "";
 }
 
-export function registerConfigCatContext(providerId?: string): React.Context<ConfigCatContextData | undefined> {
-  const context = React.createContext<ConfigCatContextData | undefined>(void 0);
-
-  context.displayName = "ConfigCatContext" + (providerId ? "_" + providerId : "");
-
-  ConfigCatContextRegistry.set(registryKeyFor(providerId), { context });
-
-  return context;
-}
-
-export function reserveConfigCatContext(providerId?: string): boolean | undefined {
-  const item = ConfigCatContextRegistry.get(registryKeyFor(providerId));
-  if (!item) return;
-  if (item.isReserved) return false;
-  return item.isReserved = true;
+export function ensureConfigCatContext(providerId?: string): React.Context<ConfigCatContextData | undefined> {
+  const key = registryKeyFor(providerId);
+  let entry = ConfigCatContextRegistry.get(key);
+  if (!entry) {
+    const context = React.createContext<ConfigCatContextData | undefined>(void 0);
+    context.displayName = "ConfigCatContext" + (providerId ? "_" + providerId : "");
+    ConfigCatContextRegistry.set(key, entry = { context, refCount: 0 });
+  }
+  return entry.context;
 }
 
 export function getConfigCatContext(providerId?: string): React.Context<ConfigCatContextData | undefined> | undefined {
   return ConfigCatContextRegistry.get(registryKeyFor(providerId))?.context;
 }
 
-export function unregisterConfigCatContext(providerId?: string): boolean {
-  return ConfigCatContextRegistry.delete(registryKeyFor(providerId));
+export function registerConfigCatContextUsage(providerId?: string): boolean {
+  const entry = ConfigCatContextRegistry.get(registryKeyFor(providerId));
+  if (!entry) return false;
+  entry.refCount++;
+  return true;
+}
+
+export function unregisterConfigCatContextUsage(providerId?: string): boolean {
+  const key = registryKeyFor(providerId);
+  const entry = ConfigCatContextRegistry.get(key);
+  if (!entry) return false;
+
+  entry.refCount--;
+  if (entry.refCount > 0) {
+    return false;
+  }
+
+  ConfigCatContextRegistry.delete(key);
+  return true;
 }

--- a/src/ConfigCatContext.tsx
+++ b/src/ConfigCatContext.tsx
@@ -7,10 +7,7 @@ export interface ConfigCatContextData {
 }
 
 /** @remarks Map key: provider id normalized to lower case. */
-const ConfigCatContextRegistry = new Map<string, {
-  context: React.Context<ConfigCatContextData | undefined>;
-  refCount: number;
-}>();
+const ConfigCatContextRegistry = new Map<string, React.Context<ConfigCatContextData | undefined>>();
 
 function registryKeyFor(providerId: string | undefined) {
   return providerId ? providerId.toLowerCase() : "";
@@ -18,36 +15,15 @@ function registryKeyFor(providerId: string | undefined) {
 
 export function ensureConfigCatContext(providerId?: string): React.Context<ConfigCatContextData | undefined> {
   const key = registryKeyFor(providerId);
-  let entry = ConfigCatContextRegistry.get(key);
-  if (!entry) {
-    const context = React.createContext<ConfigCatContextData | undefined>(void 0);
+  let context = ConfigCatContextRegistry.get(key);
+  if (!context) {
+    context = React.createContext<ConfigCatContextData | undefined>(void 0);
     context.displayName = "ConfigCatContext" + (providerId ? "_" + providerId : "");
-    ConfigCatContextRegistry.set(key, entry = { context, refCount: 0 });
+    ConfigCatContextRegistry.set(key, context);
   }
-  return entry.context;
+  return context;
 }
 
 export function getConfigCatContext(providerId?: string): React.Context<ConfigCatContextData | undefined> | undefined {
-  return ConfigCatContextRegistry.get(registryKeyFor(providerId))?.context;
-}
-
-export function registerConfigCatContextUsage(providerId?: string): boolean {
-  const entry = ConfigCatContextRegistry.get(registryKeyFor(providerId));
-  if (!entry) return false;
-  entry.refCount++;
-  return true;
-}
-
-export function unregisterConfigCatContextUsage(providerId?: string): boolean {
-  const key = registryKeyFor(providerId);
-  const entry = ConfigCatContextRegistry.get(key);
-  if (!entry) return false;
-
-  entry.refCount--;
-  if (entry.refCount > 0) {
-    return false;
-  }
-
-  ConfigCatContextRegistry.delete(key);
-  return true;
+  return ConfigCatContextRegistry.get(registryKeyFor(providerId));
 }

--- a/src/ConfigCatHooks.tsx
+++ b/src/ConfigCatHooks.tsx
@@ -2,15 +2,17 @@
 
 import type { IConfigCatClient, SettingTypeOf, SettingValue, User } from "configcat-common";
 import { useContext, useEffect, useState } from "react";
-import ConfigCatContext, { getOrCreateConfigCatContext } from "./ConfigCatContext";
+import { getConfigCatContext } from "./ConfigCatContext";
 import { createConfigCatProviderError } from "./ConfigCatProvider";
 
 function useFeatureFlag<T extends SettingValue>(key: string, defaultValue: T, user?: User, providerId?: string): {
   value: SettingTypeOf<T>;
   loading: boolean;
 } {
-  const configCatContext = useContext(providerId ? getOrCreateConfigCatContext(providerId) : ConfigCatContext);
+  const configCatContextObj = getConfigCatContext(providerId);
+  if (!configCatContextObj) throw createConfigCatProviderError("useFeatureFlag", providerId);
 
+  const configCatContext = useContext(configCatContextObj);
   if (!configCatContext) throw createConfigCatProviderError("useFeatureFlag", providerId);
 
   const [featureFlagValue, setFeatureFlag] = useState(defaultValue as SettingTypeOf<T>);
@@ -25,9 +27,10 @@ function useFeatureFlag<T extends SettingValue>(key: string, defaultValue: T, us
 }
 
 function useConfigCatClient(providerId?: string): IConfigCatClient {
+  const configCatContextObj = getConfigCatContext(providerId);
+  if (!configCatContextObj) throw createConfigCatProviderError("useConfigCatClient", providerId);
 
-  const configCatContext = useContext(providerId ? getOrCreateConfigCatContext(providerId) : ConfigCatContext);
-
+  const configCatContext = useContext(configCatContextObj);
   if (!configCatContext) throw createConfigCatProviderError("useConfigCatClient", providerId);
 
   return configCatContext.client;

--- a/src/ConfigCatProvider.tsx
+++ b/src/ConfigCatProvider.tsx
@@ -4,7 +4,7 @@ import type { ClientCacheState, HookEvents, IConfig, IConfigCatClient, IConfigCa
 import { PollingMode, getClient } from "configcat-common";
 import React, { Component, type PropsWithChildren } from "react";
 import { LocalStorageCache } from "./Cache";
-import { type ConfigCatContextData, ensureConfigCatContext, registerConfigCatContextUsage, unregisterConfigCatContextUsage } from "./ConfigCatContext";
+import { type ConfigCatContextData, ensureConfigCatContext } from "./ConfigCatContext";
 import { HttpConfigFetcher } from "./ConfigFetcher";
 import CONFIGCAT_SDK_VERSION from "./Version";
 import type { IReactAutoPollOptions, IReactLazyLoadingOptions, IReactManualPollOptions } from ".";
@@ -35,11 +35,9 @@ class ConfigCatProvider extends Component<PropsWithChildren<ConfigCatProviderPro
   }
 
   componentDidMount(): void {
-    const { id: providerId, sdkKey } = this.props;
+    const { sdkKey } = this.props;
 
     initializedClients.set(sdkKey, (initializedClients.get(sdkKey) ?? 0) + 1);
-
-    registerConfigCatContextUsage(providerId);
 
     this.configChangedHandler = newConfig => this.reactConfigChanged(newConfig);
 
@@ -59,9 +57,7 @@ class ConfigCatProvider extends Component<PropsWithChildren<ConfigCatProviderPro
       delete this.configChangedHandler;
     }
 
-    const { id: providerId, sdkKey } = this.props;
-
-    unregisterConfigCatContextUsage(providerId);
+    const { sdkKey } = this.props;
 
     const refCount = (initializedClients.get(sdkKey) ?? 1) - 1;
     initializedClients.set(sdkKey, refCount);

--- a/src/ConfigCatProvider.tsx
+++ b/src/ConfigCatProvider.tsx
@@ -4,7 +4,7 @@ import type { ClientCacheState, HookEvents, IConfig, IConfigCatClient, IConfigCa
 import { PollingMode, getClient } from "configcat-common";
 import React, { Component, type PropsWithChildren } from "react";
 import { LocalStorageCache } from "./Cache";
-import ConfigCatContext, { type ConfigCatContextData, getOrCreateConfigCatContext } from "./ConfigCatContext";
+import { type ConfigCatContextData, getConfigCatContext, registerConfigCatContext, reserveConfigCatContext, unregisterConfigCatContext } from "./ConfigCatContext";
 import { HttpConfigFetcher } from "./ConfigFetcher";
 import CONFIGCAT_SDK_VERSION from "./Version";
 import type { IReactAutoPollOptions, IReactLazyLoadingOptions, IReactManualPollOptions } from ".";
@@ -16,18 +16,23 @@ type ConfigCatProviderProps = {
   id?: string;
 };
 
-type ConfigCatProviderState = {
-  client: IConfigCatClient;
-  lastUpdated?: Date;
+type ConfigCatProviderState = ConfigCatContextData & {
 };
 
 const initializedClients = new Map<string, number>();
 
 class ConfigCatProvider extends Component<PropsWithChildren<ConfigCatProviderProps>, ConfigCatProviderState, {}> {
+  private providesSharedContext?: boolean;
   private configChangedHandler?: (newConfig: IConfig) => void;
 
   constructor(props: ConfigCatProviderProps) {
     super(props);
+
+    // Normally, we'd check here whether the specified id is unique (i.e. whether there's no other provider component that uses this id),
+    // however in some cases React calls the constructor multiple times (e.g. when an error is thrown during render or StrictMode is enabled in development).
+    // What's worse, extra component instances don't go through the normal component lifecycle (e.g. componentDidMount/componentWillUnmount won't be called).
+    // So, as a workaround, we postpone checking and reporting non-unique ids until componentDidMount.
+    // (See also: https://legacy.reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects)
 
     const client: IConfigCatClient = !isServerContext()
       ? this.initializeConfigCatClient()
@@ -37,6 +42,21 @@ class ConfigCatProvider extends Component<PropsWithChildren<ConfigCatProviderPro
   }
 
   componentDidMount(): void {
+    const { id: providerId, sdkKey } = this.props;
+
+    initializedClients.set(sdkKey, (initializedClients.get(sdkKey) ?? 0) + 1);
+
+    if (reserveConfigCatContext(providerId) === false) {
+      if (providerId) {
+        throw Error(`The component tree already contains a ConfigCatProvider${providerIdText(providerId)}. Please make sure that this id is assigned only to a single instance of ConfigCatProvider.`);
+      }
+      else {
+        // To avoid breaking existing code, we allow multiple instances of the provider with no id attribute.
+        console.warn(`The component tree already contains a ConfigCatProvider${providerIdText(providerId)}. To avoid unexpected behavior, please use only a single instance of ConfigCatProvider${providerIdText(providerId)}.`);
+      }
+      this.providesSharedContext = true;
+    }
+
     this.configChangedHandler = newConfig => this.reactConfigChanged(newConfig);
 
     this.state.client.waitForReady().then(() => {
@@ -50,28 +70,34 @@ class ConfigCatProvider extends Component<PropsWithChildren<ConfigCatProviderPro
   }
 
   componentWillUnmount(): void {
-    this.state.client.off("configChanged", this.configChangedHandler!);
-    delete this.configChangedHandler;
+    if (this.configChangedHandler) {
+      this.state.client.off("configChanged", this.configChangedHandler);
+      delete this.configChangedHandler;
+    }
 
-    const refCount = (initializedClients.get(this.props.sdkKey) ?? 1) - 1;
-    initializedClients.set(this.props.sdkKey, refCount);
+    const { id: providerId, sdkKey } = this.props;
+
+    if (!this.providesSharedContext) {
+      unregisterConfigCatContext(providerId);
+    }
+
+    const refCount = (initializedClients.get(sdkKey) ?? 1) - 1;
+    initializedClients.set(sdkKey, refCount);
 
     if (refCount <= 0) {
       this.state.client.dispose();
-      initializedClients.delete(this.props.sdkKey);
+      initializedClients.delete(sdkKey);
     }
   }
 
   private initializeConfigCatClient() {
-    const { pollingMode, options } = this.props;
-    const { sdkKey } = this.props;
+    const { pollingMode, options, sdkKey } = this.props;
     const configCatKernel: IConfigCatKernel = LocalStorageCache.setup({
       configFetcher: new HttpConfigFetcher(),
       sdkType: "ConfigCat-React",
       sdkVersion: CONFIGCAT_SDK_VERSION,
     });
 
-    initializedClients.set(sdkKey, (initializedClients.get(sdkKey) ?? 0) + 1);
     return getClient(sdkKey, pollingMode ?? PollingMode.AutoPoll, options, configCatKernel);
   }
 
@@ -84,8 +110,7 @@ class ConfigCatProvider extends Component<PropsWithChildren<ConfigCatProviderPro
   }
 
   render(): React.JSX.Element {
-
-    const context: React.Context<ConfigCatContextData | undefined> = this.props.id ? getOrCreateConfigCatContext(this.props.id) : ConfigCatContext;
+    const context = getConfigCatContext(this.props.id) ?? registerConfigCatContext(this.props.id);
 
     return (
       <context.Provider value={this.state}>
@@ -106,14 +131,23 @@ function serverContextNotSupported(): Error {
   );
 }
 
+function providerIdText(providerId?: string) {
+  return providerId ? ` with id="${providerId}"` : " without id attribute";
+}
+
+export function createConfigCatProviderError(methodName: string, providerId?: string): Error {
+  return Error(`${methodName} must be used in ConfigCatProvider${providerIdText(providerId)}!`);
+}
+
 class ConfigCatClientStub implements IConfigCatClient {
+  readonly isOffline: boolean;
+
   getValueAsync<T extends SettingValue>(_key: string, _defaultValue: T, _user?: User): Promise<SettingTypeOf<T>> {
     throw serverContextNotSupported();
   }
   getValueDetailsAsync<T extends SettingValue>(_key: string, _defaultValue: T, _user?: User): Promise<IEvaluationDetails<SettingTypeOf<T>>> {
     throw serverContextNotSupported();
   }
-
   getAllKeysAsync(): Promise<string[]> {
     throw serverContextNotSupported();
   }
@@ -141,7 +175,6 @@ class ConfigCatClientStub implements IConfigCatClient {
   clearDefaultUser(): void {
     throw serverContextNotSupported();
   }
-  isOffline: boolean;
   setOnline(): void {
     throw serverContextNotSupported();
   }
@@ -178,13 +211,6 @@ class ConfigCatClientStub implements IConfigCatClient {
   eventNames(): (keyof HookEvents)[] {
     throw serverContextNotSupported();
   }
-}
-
-export function createConfigCatProviderError(methodName: string, providerId?: string): Error {
-
-  const providerIdText: string = providerId ? ` with id="${providerId}"` : " without id attribute";
-
-  return Error(`${methodName} must be used in ConfigCatProvider${providerIdText}!`);
 }
 
 export default ConfigCatProvider;


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR proposes a few improvements that solve the following issues with the base PR:
* ~The soft memory leak discussed [here](https://github.com/configcat/react-sdk/pull/58#discussion_r1778735777). (This PR makes changes to get rid of `React.Context<...>` instances when the related provider component gets unmounted.)~ We decided that this doesn't seem like an actual issue. If it turns out it to be, we will come back to the issue.
* `React.Context<...>` instances can also be created on the "consumer side", e.g. by `withConfigCatClient`, `useConfigCatClient`, etc. (This PR makes changes so context instances are only retrieved but never created by these functions.)
* ~Nothing stops consumers to add multiple `ConfigCatProvider`s with the same id (and even different SDK keys), which may lead to confusing behavior. (For backward compatibility, this PR keeps this behavior for providers with no id attribute but logs a warning to the console when multiple instances are detected. However, makes changes to throw an error when a non-empty id is used multiple times.)~ UPDATE: This is kind of invalid as goes against how React contexts work. So, on second thought, it doesn't seem like a good idea to add these checks.
* The reference counting of `ConfigCatClient` instances obtained via `ConfigCatProvider` is buggy as React calls the constructor of the provider component multiple times in some cases (e.g. when an error is thrown during render or StrictMode is enabled in development). (This PR moves the reference count incrementing logic to `componentDidMount` to be resistant to this behavior.)

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
