### PR TITLE
Implement a query string flag override data source

### DIFF
--- a/.github/workflows/ux-label-mention.yml
+++ b/.github/workflows/ux-label-mention.yml
@@ -1,0 +1,16 @@
+name: Mention Teams
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  react-to-labels:
+    uses: configcat/.github/.github/workflows/ux-label-mention.yml@master
+    with:
+      id: ${{ github.event.pull_request.number }}
+      repo: ${{ github.repository }}
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      slack_webhook_url: ${{ secrets.TEXT_REVIEW_SLACK_WEBHOOK_URL }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configcat-react",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-react",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "license": "MIT",
       "dependencies": {
         "configcat-common": "9.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-react",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc -p tsconfig.build.esm.json && gulp esm",

--- a/src/FlagOverrides.test.tsx
+++ b/src/FlagOverrides.test.tsx
@@ -13,12 +13,12 @@ describe("Flag Overrides", () => {
   it("Query string override should work - changes not watched", async () => {
     const TestComponent = () => {
       const { value: featureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
-      return (< div>Feature flag value: {featureFlag}</div>);
+      return (<div>Feature flag value: {featureFlag}</div>);
     };
 
-    const queryStringProvider: IQueryStringProvider & { currentValue?: string } = {
+    const queryStringProvider = {
       currentValue: "?cc-stringDefaultCat=OVERRIDE_CAT&stringDefaultCat=NON_OVERRIDE_CAT"
-    };
+    } satisfies IQueryStringProvider;
 
     const options: IReactAutoPollOptions = {
       flagOverrides: createFlagOverridesFromQueryParams(OverrideBehaviour.LocalOverRemote, false, void 0, queryStringProvider)
@@ -39,12 +39,12 @@ describe("Flag Overrides", () => {
   it("Query string override should work - changes watched", async () => {
     const TestComponent = () => {
       const { value: featureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
-      return (< div>Feature flag value: {featureFlag}</div>);
+      return (<div>Feature flag value: {featureFlag}</div>);
     };
 
-    const queryStringProvider: IQueryStringProvider & { currentValue?: string } = {
+    const queryStringProvider = {
       currentValue: "?cc-stringDefaultCat=OVERRIDE_CAT"
-    };
+    } satisfies IQueryStringProvider;
 
     const options: IReactAutoPollOptions = {
       flagOverrides: createFlagOverridesFromQueryParams(OverrideBehaviour.LocalOverRemote, true, void 0, queryStringProvider)
@@ -62,15 +62,41 @@ describe("Flag Overrides", () => {
     await screen.findByText("Feature flag value: CHANGED_OVERRIDE_CAT", void 0, { timeout: 2000 });
   });
 
+  it("Query string override should work -q parsed query string", async () => {
+    const TestComponent = () => {
+      const { value: featureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
+      return (<div>Feature flag value: {featureFlag}</div>);
+    };
+
+    const queryStringProvider = {
+      currentValue: { "cc-stringDefaultCat": "OVERRIDE_CAT" as string | ReadonlyArray<string> }
+    } satisfies IQueryStringProvider;
+
+    const options: IReactAutoPollOptions = {
+      flagOverrides: createFlagOverridesFromQueryParams(OverrideBehaviour.LocalOverRemote, true, void 0, queryStringProvider)
+    };
+
+    const ui = <ConfigCatProvider sdkKey={sdkKey} options={options}><TestComponent /></ConfigCatProvider>;
+
+    await render(ui);
+    await screen.findByText("Feature flag value: OVERRIDE_CAT", void 0, { timeout: 2000 });
+
+    cleanup();
+    queryStringProvider.currentValue = { "cc-stringDefaultCat": ["OVERRIDE_CAT", "CHANGED_OVERRIDE_CAT"] };
+
+    await render(ui);
+    await screen.findByText("Feature flag value: CHANGED_OVERRIDE_CAT", void 0, { timeout: 2000 });
+  });
+
   it("Query string override should work - respects custom parameter name prefix", async () => {
     const TestComponent = () => {
       const { value: featureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
-      return (< div>Feature flag value: {featureFlag}</div>);
+      return (<div>Feature flag value: {featureFlag}</div>);
     };
 
-    const queryStringProvider: IQueryStringProvider & { currentValue?: string } = {
+    const queryStringProvider = {
       currentValue: "?stringDefaultCat=OVERRIDE_CAT&cc-stringDefaultCat=NON_OVERRIDE_CAT"
-    };
+    } satisfies IQueryStringProvider;
 
     const options: IReactAutoPollOptions = {
       flagOverrides: createFlagOverridesFromQueryParams(OverrideBehaviour.LocalOverRemote, void 0, "", queryStringProvider)
@@ -86,12 +112,12 @@ describe("Flag Overrides", () => {
     const TestComponent = () => {
       const { value: boolFeatureFlag } = useFeatureFlag("boolDefaultFalse", false);
       const { value: stringFeatureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
-      return (< div>Feature flag values: {boolFeatureFlag ? "true" : "false"} ({typeof boolFeatureFlag}), {stringFeatureFlag} ({typeof stringFeatureFlag})</div>);
+      return (<div>Feature flag values: {boolFeatureFlag ? "true" : "false"} ({typeof boolFeatureFlag}), {stringFeatureFlag} ({typeof stringFeatureFlag})</div>);
     };
 
-    const queryStringProvider: IQueryStringProvider & { currentValue?: string } = {
+    const queryStringProvider = {
       currentValue: "?stringDefaultCat;str=TRUE&boolDefaultFalse=TRUE"
-    };
+    } satisfies IQueryStringProvider;
 
     const options: IReactAutoPollOptions = {
       flagOverrides: createFlagOverridesFromQueryParams(OverrideBehaviour.LocalOverRemote, void 0, "", queryStringProvider)
@@ -106,12 +132,12 @@ describe("Flag Overrides", () => {
   it("Query string override should work - handles query string edge cases", async () => {
     const TestComponent = () => {
       const { value: featureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
-      return (< div>Feature flag value: {featureFlag}</div>);
+      return (<div>Feature flag value: {featureFlag}</div>);
     };
 
-    const queryStringProvider: IQueryStringProvider & { currentValue?: string } = {
+    const queryStringProvider = {
       currentValue: "?&some&=garbage&&cc-stringDefaultCat=OVERRIDE_CAT&=cc-stringDefaultCat&cc-stringDefaultCat"
-    };
+    } satisfies IQueryStringProvider;
 
     const options: IReactAutoPollOptions = {
       flagOverrides: createFlagOverridesFromQueryParams(OverrideBehaviour.LocalOverRemote, void 0, void 0, queryStringProvider)

--- a/src/FlagOverrides.test.tsx
+++ b/src/FlagOverrides.test.tsx
@@ -1,0 +1,126 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import { useFeatureFlag } from "./ConfigCatHooks";
+import ConfigCatProvider from "./ConfigCatProvider";
+import type { IQueryStringProvider, IReactAutoPollOptions } from ".";
+import { OverrideBehaviour, createFlagOverridesFromQueryParams } from ".";
+
+const sdkKey = "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A";
+
+afterEach(cleanup);
+
+describe("Flag Overrides", () => {
+  it("Query string override should work - changes not watched", async () => {
+    const TestComponent = () => {
+      const { value: featureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
+      return (< div>Feature flag value: {featureFlag}</div>);
+    };
+
+    const queryStringProvider: IQueryStringProvider & { currentValue?: string } = {
+      currentValue: "?cc-stringDefaultCat=OVERRIDE_CAT&stringDefaultCat=NON_OVERRIDE_CAT"
+    };
+
+    const options: IReactAutoPollOptions = {
+      flagOverrides: createFlagOverridesFromQueryParams(OverrideBehaviour.LocalOverRemote, false, void 0, queryStringProvider)
+    };
+
+    const ui = <ConfigCatProvider sdkKey={sdkKey} options={options}><TestComponent /></ConfigCatProvider>;
+
+    await render(ui);
+    await screen.findByText("Feature flag value: OVERRIDE_CAT", void 0, { timeout: 2000 });
+
+    cleanup();
+    queryStringProvider.currentValue = "?cc-stringDefaultCat=CHANGED_OVERRIDE_CAT";
+
+    await render(ui);
+    await screen.findByText("Feature flag value: OVERRIDE_CAT", void 0, { timeout: 2000 });
+  });
+
+  it("Query string override should work - changes watched", async () => {
+    const TestComponent = () => {
+      const { value: featureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
+      return (< div>Feature flag value: {featureFlag}</div>);
+    };
+
+    const queryStringProvider: IQueryStringProvider & { currentValue?: string } = {
+      currentValue: "?cc-stringDefaultCat=OVERRIDE_CAT"
+    };
+
+    const options: IReactAutoPollOptions = {
+      flagOverrides: createFlagOverridesFromQueryParams(OverrideBehaviour.LocalOverRemote, true, void 0, queryStringProvider)
+    };
+
+    const ui = <ConfigCatProvider sdkKey={sdkKey} options={options}><TestComponent /></ConfigCatProvider>;
+
+    await render(ui);
+    await screen.findByText("Feature flag value: OVERRIDE_CAT", void 0, { timeout: 2000 });
+
+    cleanup();
+    queryStringProvider.currentValue = "?cc-stringDefaultCat=CHANGED_OVERRIDE_CAT";
+
+    await render(ui);
+    await screen.findByText("Feature flag value: CHANGED_OVERRIDE_CAT", void 0, { timeout: 2000 });
+  });
+
+  it("Query string override should work - respects custom parameter name prefix", async () => {
+    const TestComponent = () => {
+      const { value: featureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
+      return (< div>Feature flag value: {featureFlag}</div>);
+    };
+
+    const queryStringProvider: IQueryStringProvider & { currentValue?: string } = {
+      currentValue: "?stringDefaultCat=OVERRIDE_CAT&cc-stringDefaultCat=NON_OVERRIDE_CAT"
+    };
+
+    const options: IReactAutoPollOptions = {
+      flagOverrides: createFlagOverridesFromQueryParams(OverrideBehaviour.LocalOverRemote, void 0, "", queryStringProvider)
+    };
+
+    const ui = <ConfigCatProvider sdkKey={sdkKey} options={options}><TestComponent /></ConfigCatProvider>;
+
+    await render(ui);
+    await screen.findByText("Feature flag value: OVERRIDE_CAT", void 0, { timeout: 2000 });
+  });
+
+  it("Query string override should work - respects force-value-to-be-interpreted-as-string suffix", async () => {
+    const TestComponent = () => {
+      const { value: boolFeatureFlag } = useFeatureFlag("boolDefaultFalse", false);
+      const { value: stringFeatureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
+      return (< div>Feature flag values: {boolFeatureFlag ? "true" : "false"} ({typeof boolFeatureFlag}), {stringFeatureFlag} ({typeof stringFeatureFlag})</div>);
+    };
+
+    const queryStringProvider: IQueryStringProvider & { currentValue?: string } = {
+      currentValue: "?stringDefaultCat;str=TRUE&boolDefaultFalse=TRUE"
+    };
+
+    const options: IReactAutoPollOptions = {
+      flagOverrides: createFlagOverridesFromQueryParams(OverrideBehaviour.LocalOverRemote, void 0, "", queryStringProvider)
+    };
+
+    const ui = <ConfigCatProvider sdkKey={sdkKey} options={options}><TestComponent /></ConfigCatProvider>;
+
+    await render(ui);
+    await screen.findByText("Feature flag values: true (boolean), TRUE (string)", void 0, { timeout: 2000 });
+  });
+
+  it("Query string override should work - handles query string edge cases", async () => {
+    const TestComponent = () => {
+      const { value: featureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
+      return (< div>Feature flag value: {featureFlag}</div>);
+    };
+
+    const queryStringProvider: IQueryStringProvider & { currentValue?: string } = {
+      currentValue: "?&some&=garbage&&cc-stringDefaultCat=OVERRIDE_CAT&=cc-stringDefaultCat&cc-stringDefaultCat"
+    };
+
+    const options: IReactAutoPollOptions = {
+      flagOverrides: createFlagOverridesFromQueryParams(OverrideBehaviour.LocalOverRemote, void 0, void 0, queryStringProvider)
+    };
+
+    const ui = <ConfigCatProvider sdkKey={sdkKey} options={options}><TestComponent /></ConfigCatProvider>;
+
+    await render(ui);
+    await screen.findByText("Feature flag value:", void 0, { timeout: 2000 });
+    await expect(() => screen.findByText("Feature flag value: OVERRIDE_CAT", void 0, { timeout: 2000 })).rejects.toThrow();
+  });
+});

--- a/src/FlagOverrides.test.tsx
+++ b/src/FlagOverrides.test.tsx
@@ -62,7 +62,7 @@ describe("Flag Overrides", () => {
     await screen.findByText("Feature flag value: CHANGED_OVERRIDE_CAT", void 0, { timeout: 2000 });
   });
 
-  it("Query string override should work -q parsed query string", async () => {
+  it("Query string override should work - parsed query string", async () => {
     const TestComponent = () => {
       const { value: featureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");
       return (<div>Feature flag value: {featureFlag}</div>);
@@ -108,7 +108,7 @@ describe("Flag Overrides", () => {
     await screen.findByText("Feature flag value: OVERRIDE_CAT", void 0, { timeout: 2000 });
   });
 
-  it("Query string override should work - respects force-value-to-be-interpreted-as-string suffix", async () => {
+  it("Query string override should work - respects force string value suffix", async () => {
     const TestComponent = () => {
       const { value: boolFeatureFlag } = useFeatureFlag("boolDefaultFalse", false);
       const { value: stringFeatureFlag } = useFeatureFlag("stringDefaultCat", "NOT_CAT");

--- a/src/FlagOverrides.ts
+++ b/src/FlagOverrides.ts
@@ -1,0 +1,137 @@
+import { type FlagOverrides, OverrideBehaviour, type SettingValue, createFlagOverridesFromMap } from "configcat-common";
+
+export interface IQueryStringProvider {
+  readonly currentValue?: string;
+}
+
+class DefaultQueryStringProvider implements IQueryStringProvider {
+  get currentValue() { return window?.location.search; }
+}
+
+let defaultQueryStringProvider: DefaultQueryStringProvider | undefined;
+
+export class QueryParamsOverrideDataSource implements IOverrideDataSource {
+  private readonly watchChanges?: boolean;
+  private readonly paramPrefix: string;
+  private readonly queryStringProvider: IQueryStringProvider;
+  private queryString: string | undefined;
+  private settings: { [name: string]: Setting };
+
+  constructor(watchChanges?: boolean, paramPrefix?: string, queryStringProvider?: IQueryStringProvider) {
+    this.watchChanges = watchChanges;
+    this.paramPrefix = paramPrefix ?? "cc-";
+
+    queryStringProvider ??= defaultQueryStringProvider ??= new DefaultQueryStringProvider();
+    this.queryStringProvider = queryStringProvider;
+
+    const currentQueryString = queryStringProvider.currentValue;
+    this.queryString = currentQueryString;
+    this.settings = extractSettingsFromQueryString(currentQueryString, this.paramPrefix);
+  }
+
+  getOverrides(): Promise<{ [name: string]: Setting }> {
+    return Promise.resolve(this.getOverridesSync());
+  }
+
+  getOverridesSync(): { [name: string]: Setting } {
+    if (this.watchChanges) {
+      const currentQueryString = this.queryStringProvider.currentValue;
+      if (currentQueryString !== this.queryString) {
+        this.queryString = currentQueryString;
+        this.settings = extractSettingsFromQueryString(currentQueryString, this.paramPrefix);
+      }
+    }
+
+    return this.settings;
+  }
+}
+
+function extractSettingsFromQueryString(queryString: string | undefined, paramPrefix: string) {
+  const settings: { [name: string]: Setting } = {};
+
+  if (!queryString
+    || queryString.lastIndexOf("?", 0) < 0) { // identical to `queryString.startsWith("?")`
+    return settings;
+  }
+
+  const parts = queryString.substring(1).split("&");
+  for (let part of parts) {
+    part = part.replace(/\+/g, " ");
+    const index = part.indexOf("=");
+
+    let key = decodeURIComponent(index >= 0 ? part.substring(0, index) : part);
+    if (!key
+      || key.length <= paramPrefix.length
+      || key.lastIndexOf(paramPrefix, 0) < 0) { // identical to `!key.startsWith(paramPrefix)`
+      continue;
+    }
+    key = key.substring(paramPrefix.length);
+
+    const strSuffix = ";str";
+    const forceInterpretValueAsString = key.length > strSuffix.length
+      && key.indexOf(strSuffix, key.length - strSuffix.length) >= 0; // identical to `key.endsWith(strSuffix)`
+
+    let value: boolean | string | number = index > -1 ? decodeURIComponent(part.substring(index + 1)) : "";
+
+    if (forceInterpretValueAsString) {
+      key = key.substring(0, key.length - strSuffix.length);
+    }
+    else {
+      value = parseQueryStringValue(value);
+    }
+
+    settings[key] = settingConstuctor.fromValue(value);
+  }
+
+  return settings;
+}
+
+function parseQueryStringValue(value: string): boolean | string | number {
+  switch (value.toLowerCase()) {
+    case "false":
+      return false;
+    case "true":
+      return true;
+    default:
+      const number = parseFloatStrict(value);
+      return !isNaN(number) ? number : value;
+  }
+}
+
+function parseFloatStrict(value: string): number {
+  // NOTE: JS's float to string conversion is too forgiving, it converts whitespace string to 0 and accepts hex numbers.
+
+  if (!value.length || /^\s*$|^\s*0[^\d.e]/.test(value)) {
+    return NaN;
+  }
+
+  return +value;
+}
+
+// The following types and functions aren't part of configcat-common's public API,
+// so for now we need this hack to make things work.
+// TODO: move the flag override data source into the new unified JS SDK and
+// get rid of this workaround as soon as it's released.
+
+type IOverrideDataSource = FlagOverrides["dataSource"];
+
+type Setting = ReturnType<IOverrideDataSource["getOverridesSync"]>[""];
+
+type FlagOverridesConstructor = {
+  new(dataSource: IOverrideDataSource, behaviour: OverrideBehaviour): FlagOverrides;
+}
+
+type SettingConstructor = {
+  fromValue(value: NonNullable<SettingValue>): Setting;
+};
+
+const [flagOverridesConstructor, settingConstuctor] = (() => {
+  const dummyFlagOverrides = createFlagOverridesFromMap({ "$": 0 }, OverrideBehaviour.LocalOnly);
+  const dummySetting = dummyFlagOverrides.dataSource.getOverridesSync()["$"];
+  return [
+    (dummyFlagOverrides as any).constructor as FlagOverridesConstructor,
+    (dummySetting as any).constructor as SettingConstructor
+  ];
+})();
+
+export { flagOverridesConstructor };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import type { GetValueType, WithConfigCatClientProps } from "./ConfigCatHOC";
 import withConfigCatClient from "./ConfigCatHOC";
 import { useConfigCatClient, useFeatureFlag } from "./ConfigCatHooks";
 import ConfigCatProvider from "./ConfigCatProvider";
-import type { IQueryStringProvider} from "./FlagOverrides";
+import type { IQueryStringProvider } from "./FlagOverrides";
 import { QueryParamsOverrideDataSource, flagOverridesConstructor } from "./FlagOverrides";
 
 export { createConsoleLogger, createFlagOverridesFromMap } from "configcat-common";
@@ -21,7 +21,7 @@ export { createConsoleLogger, createFlagOverridesFromMap } from "configcat-commo
  * specify feature flag override values. Parameters whose name doesn't start with the
  * prefix will be ignored. Defaults to `cc-`.
  * @param queryStringProvider The provider object used to obtain the query string.
- * Defaults to a provider that extracts query string from the URL returned by `window.location.href`.
+ * Defaults to a provider that returns the value of `window.location.search`.
  */
 export function createFlagOverridesFromQueryParams(behaviour: OverrideBehaviour,
   watchChanges?: boolean, paramPrefix?: string, queryStringProvider?: IQueryStringProvider

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,24 @@ import type { GetValueType, WithConfigCatClientProps } from "./ConfigCatHOC";
 import withConfigCatClient from "./ConfigCatHOC";
 import { useConfigCatClient, useFeatureFlag } from "./ConfigCatHooks";
 import ConfigCatProvider from "./ConfigCatProvider";
-import { flagOverridesConstructor, IQueryStringProvider, QueryParamsOverrideDataSource } from "./FlagOverrides";
+import type { IQueryStringProvider} from "./FlagOverrides";
+import { QueryParamsOverrideDataSource, flagOverridesConstructor } from "./FlagOverrides";
 
 export { createConsoleLogger, createFlagOverridesFromMap } from "configcat-common";
 
+/**
+ * Creates an instance of `FlagOverrides` that uses query string parameters as data source.
+ * @param behaviour The override behaviour.
+ * Specifies whether the local values should override the remote values
+ * or local values should only be used when a remote value doesn't exist
+ * or the local values should be used only.
+ * @param watchChanges If set to `true`, the query string will be tracked for changes.
+ * @param paramPrefix The parameter name prefix used to indicate which query string parameters
+ * specify feature flag override values. Parameters whose name doesn't start with the
+ * prefix will be ignored. Defaults to `cc-`.
+ * @param queryStringProvider The provider object used to obtain the query string.
+ * Defaults to a provider that extracts query string from the URL returned by `window.location.href`.
+ */
 export function createFlagOverridesFromQueryParams(behaviour: OverrideBehaviour,
   watchChanges?: boolean, paramPrefix?: string, queryStringProvider?: IQueryStringProvider
 ): FlagOverrides {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,21 @@
 "use client";
 
-import type { IAutoPollOptions, IConfigCatLogger, ILazyLoadingOptions, IManualPollOptions } from "configcat-common";
+import type { FlagOverrides, IAutoPollOptions, IConfigCatLogger, ILazyLoadingOptions, IManualPollOptions, OverrideBehaviour } from "configcat-common";
 import type { GetValueType, WithConfigCatClientProps } from "./ConfigCatHOC";
 import withConfigCatClient from "./ConfigCatHOC";
 import { useConfigCatClient, useFeatureFlag } from "./ConfigCatHooks";
 import ConfigCatProvider from "./ConfigCatProvider";
+import { flagOverridesConstructor, IQueryStringProvider, QueryParamsOverrideDataSource } from "./FlagOverrides";
 
 export { createConsoleLogger, createFlagOverridesFromMap } from "configcat-common";
+
+export function createFlagOverridesFromQueryParams(behaviour: OverrideBehaviour,
+  watchChanges?: boolean, paramPrefix?: string, queryStringProvider?: IQueryStringProvider
+): FlagOverrides {
+  return new flagOverridesConstructor(new QueryParamsOverrideDataSource(watchChanges, paramPrefix, queryStringProvider), behaviour);
+}
+
+export type { IQueryStringProvider };
 
 /** Options used to configure the ConfigCat SDK in the case of Auto Polling mode. */
 export type IReactAutoPollOptions = IAutoPollOptions;
@@ -68,4 +77,3 @@ export { OverrideBehaviour } from "configcat-common";
 export { ClientCacheState, RefreshResult } from "configcat-common";
 
 export type { IProvidesHooks, HookEvents } from "configcat-common";
-


### PR DESCRIPTION
### Describe the purpose of your pull request

Based on a user request, adds a flag override data source that use the browser URL's query string as its source.

Note that this is meant to be an experimental feature, which, if works out, will probably be included in all the SDKs running in the browser.

### Related issues (only if applicable)

https://trello.com/c/5zOq7X4K

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
