### PR TITLE
Prevent unwanted dispose in development when Strict Mode is enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configcat-react",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "configcat-react",
-      "version": "4.8.0",
+      "version": "4.8.1",
       "license": "MIT",
       "dependencies": {
         "configcat-common": "9.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configcat-react",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "scripts": {
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc -p tsconfig.build.esm.json && gulp esm",

--- a/src/ConfigCatProvider.tsx
+++ b/src/ConfigCatProvider.tsx
@@ -18,7 +18,9 @@ type ConfigCatProviderProps = {
 
 type ConfigCatProviderState = ConfigCatContextData;
 
-const initializedClients = new Map<string, number>();
+type AugmentedConfigCatClient = IConfigCatClient & {
+  $reactSdk_providers?: Set<ConfigCatProvider>;
+}
 
 class ConfigCatProvider extends Component<PropsWithChildren<ConfigCatProviderProps>, ConfigCatProviderState, {}> {
   private configChangedHandler?: (newConfig: IConfig) => void;
@@ -26,13 +28,13 @@ class ConfigCatProvider extends Component<PropsWithChildren<ConfigCatProviderPro
   constructor(props: ConfigCatProviderProps) {
     super(props);
 
-    const { sdkKey } = this.props;
-
-    const client: IConfigCatClient = !isServerContext()
+    const client = (!isServerContext()
       ? this.initializeConfigCatClient()
-      : new ConfigCatClientStub();
+      : new ConfigCatClientStub()
+    ) as AugmentedConfigCatClient;
 
-    initializedClients.set(sdkKey, (initializedClients.get(sdkKey) ?? 0) + 1);
+    const providers = client.$reactSdk_providers ??= new Set();
+    providers.add(this);
 
     this.state = { client };
   }
@@ -56,14 +58,9 @@ class ConfigCatProvider extends Component<PropsWithChildren<ConfigCatProviderPro
       delete this.configChangedHandler;
     }
 
-    const { sdkKey } = this.props;
-
-    const refCount = (initializedClients.get(sdkKey) ?? 1) - 1;
-    initializedClients.set(sdkKey, refCount);
-
-    if (refCount <= 0) {
+    const providers = (this.state.client as AugmentedConfigCatClient).$reactSdk_providers;
+    if (providers?.delete(this) && !providers.size) {
       this.state.client.dispose();
-      initializedClients.delete(sdkKey);
     }
   }
 

--- a/src/ConfigCatProvider.tsx
+++ b/src/ConfigCatProvider.tsx
@@ -26,18 +26,18 @@ class ConfigCatProvider extends Component<PropsWithChildren<ConfigCatProviderPro
   constructor(props: ConfigCatProviderProps) {
     super(props);
 
+    const { sdkKey } = this.props;
+
     const client: IConfigCatClient = !isServerContext()
       ? this.initializeConfigCatClient()
       : new ConfigCatClientStub();
+
+    initializedClients.set(sdkKey, (initializedClients.get(sdkKey) ?? 0) + 1);
 
     this.state = { client };
   }
 
   componentDidMount(): void {
-    const { sdkKey } = this.props;
-
-    initializedClients.set(sdkKey, (initializedClients.get(sdkKey) ?? 0) + 1);
-
     this.configChangedHandler = newConfig => this.reactConfigChanged(newConfig);
 
     this.state.client.waitForReady().then(() => {


### PR DESCRIPTION
### Describe the purpose of your pull request

Fixes a regression introduced in v4.7.0, which caused the underlying `ConfigCatClient` to dispose at initialization in development when Strict Mode is enabled.

### Related issues (only if applicable)

https://github.com/configcat/react-sdk/issues/67

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
